### PR TITLE
feat: localize show more/less button text to Japanese

### DIFF
--- a/src/components/pages/blogs/blog/components/ListTemplate.tsx
+++ b/src/components/pages/blogs/blog/components/ListTemplate.tsx
@@ -291,7 +291,7 @@ const ListTemplate: React.FC<IListTemplate> = ({ content, sectionNumber }) => {
             onClick={handleShowMore}
             className="inline-block px-8 py-3 bg-gradient-to-r from-red-500 to-red-600 text-white font-semibold rounded-lg hover:shadow-lg hover:translate-y-[-2px] transition-all duration-200"
           >
-            {show ? "Show Less" : "Show More"}
+            {show ? "閉じる" : "もっとみる"}
           </button>
         </div>
       )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated the blog list expansion button labels to Japanese, displaying “もっとみる” for expanding and “閉じる” for collapsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->